### PR TITLE
Fixed case

### DIFF
--- a/id3_version.php
+++ b/id3_version.php
@@ -3,7 +3,7 @@
 	$mp3directory = $configs->MP3_DIRECTORY;
 
     $mp3 = array();
-	require_once('getid3/getid3.php');
+	require_once('getID3/getid3.php');
 	$getid3_engine = new getID3;
 	// confirm directory exists 
 	if (file_exists($mp3directory)) {


### PR DESCRIPTION
The require_once() directive included a lowercase getid3/ directory, but the directory in this distribution is capitalized as getID3.